### PR TITLE
bin/sandbox 実行時の NameError を修正

### DIFF
--- a/lib/flash_unified.rb
+++ b/lib/flash_unified.rb
@@ -6,6 +6,10 @@ require "flash_unified/version"
 # attempt to load the engine.
 require "flash_unified/engine" if defined?(Rails)
 
+# Installer is a small, framework-agnostic helper used by the generator
+# and needs to be available when running generator code outside of Rails.
+require "flash_unified/installer"
+
 module FlashUnified
   class Error < StandardError; end
   # Your code goes here...


### PR DESCRIPTION
bin/sandbox を実行すると `uninitialized constant FlashUnified::Installer (NameError)` が出ていたので修正します。

---

This pull request makes a minor update to the `lib/flash_unified.rb` file to ensure the `flash_unified/installer` helper is loaded. This change allows the installer to be available when running generator code outside of Rails environments.

* Added a `require "flash_unified/installer"` statement to make the `Installer` helper accessible for generator code outside of Rails.