### PR TITLE
CI: DB のセットアップ・ステップを取り除く

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,12 +159,17 @@ jobs:
         run: |
           bundle exec appraisal install
 
-      - name: Check installed browser
+      - name: Check installed browser (install if missing)
         run: |
           echo "which chrome/google-chrome chromium chromium-browser:"
           which google-chrome-stable || which google-chrome || which chrome || which chromium-browser || which chromium || true
           echo "versions:"
           google-chrome-stable --version 2>/dev/null || google-chrome --version 2>/dev/null || chrome --version 2>/dev/null || chromium-browser --version 2>/dev/null || chromium --version 2>/dev/null || echo "no chrome/chromium found"
+          if ! (which google-chrome-stable || which google-chrome || which chrome || which chromium-browser || which chromium); then
+            echo "Installing chromium..."
+            sudo apt-get update -y
+            sudo apt-get install -y chromium-browser --no-install-recommends
+          fi
 
       - name: Run dummy system test under appraisal
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,11 +159,6 @@ jobs:
         run: |
           bundle exec appraisal install
 
-      - name: Prepare dummy DB under appraisal
-        run: |
-          # Prepare the dummy app database inside the appraisal context
-          bundle exec appraisal ${APPRAISAL} bash -lc "cd test/dummy && bundle exec rake db:drop db:create db:migrate RAILS_ENV=test"
-
       - name: Run dummy system test under appraisal
         run: |
           bundle exec appraisal ${APPRAISAL} rake test:system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,13 @@ jobs:
         run: |
           bundle exec appraisal install
 
+      - name: Check installed browser
+        run: |
+          echo "which chrome/google-chrome chromium chromium-browser:"
+          which google-chrome-stable || which google-chrome || which chrome || which chromium-browser || which chromium || true
+          echo "versions:"
+          google-chrome-stable --version 2>/dev/null || google-chrome --version 2>/dev/null || chrome --version 2>/dev/null || chromium-browser --version 2>/dev/null || chromium --version 2>/dev/null || echo "no chrome/chromium found"
+
       - name: Run dummy system test under appraisal
         run: |
           bundle exec appraisal ${APPRAISAL} rake test:system


### PR DESCRIPTION
二点あります:
1. DB のセットアップ・ステップを取り除く
2. Chrome が入っていない場合はインストール

## 1. DB のセットアップ・ステップを取り除く

CI によるシステムテストの手順の中で DB をセットアップする手順が入っており、実行を妨げることはないのですが、ログに不可解な例外が見えるので、これを避けるためにもDB をセットアップする手順を取り除きます。

例外はこういうものです：
```
bin/rails aborted!
ArgumentError: Unknown migration version "8.0"; expected one of "4.2", "5.0", "5.1", "5.2", "6.0", "6.1", "7.0", "7.1" (ArgumentError)

          raise ArgumentError, "Unknown migration version #{version.inspect}; expected one of #{versions.sort.join(', ')}"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.../db/schema.rb:13:in `<top (required)>'
Tasks: TOP => db:test:load_schema
(See full trace by running task with --trace)
```

Appraisals で 7.1/7.2/8.0 の順番で繰り返し db:migrate が行われ（この時点でこの手順は正しくないが、それはさておき現状がこうなっていたので、その状況下で説明をつづけます）、 db/schema.rb が作成されます。 db/schema.rb は Rails バージョンごとに位置を変えているわけではないので上書きされ、最後の 8.0 のものだけが残ります。

この状態で次のステップ=テストへ進むのですが、ここでも Appraisals で 7.1/7.2/8.0 の順にテストが走ろうとします。最初は 7.1 なのですが、 test_helper.rb にて require している "rails/test_help" が、test 用DBをこの schema.rb から作成する処理が入るところで、その schema.rb の状態が 8.0 のものであると定義されているため、 7.1 の ActiveRecord::Migration の処理が、自身より新しいバージョンをみていることになるため、上記の例外が発生します。

```
ActiveRecord::Schema[8.0].define(version: 0) do
end
```

ただ、ここで一つ疑問があったのですが、エラーメッセージに  aborted! とあるように、マイグレーション処理は以上終了で落ちているはずなのですが、 CI のステップ（テスト実行）は落ちないで先へ進んでおり、さらにテストの成功まで報告している点です。

これは色々追って行った結果、例外をだしているのは ActiveRecord::Migration の中で **system コマンドから実行している**  `bin/rails db:test:prepare` の処理であったのです。そして呼び出し側ではその system の成否をチェックしておらず、コマンドが失敗しても何もケアしていないので例外にならない、ということでした。

https://github.com/rails/rails/blob/v8.0.3/activerecord/lib/active_record/migration.rb#L775-L783
```
        def load_schema!
          # Roundtrip to Rake to allow plugins to hook into database initialization.
          root = defined?(ENGINE_ROOT) ? ENGINE_ROOT : Rails.root

          FileUtils.cd(root) do
            Base.connection_handler.clear_all_connections!(:all)
            system("bin/rails db:test:prepare")
          end
        end
```

この system の呼び出し方はちょっと意外でしたが、けっこう昔からこのような処理のようでした。とりあえず、 CI のほうでは DB のセットアップは無駄なので取り除いて解決（回避）することなので、この PR のとおりです。

## 2. Chrome が入っていない場合はインストール

ランナーには Chrome が入っているようでしたので、明示的にインストールしていなくても cuprite は実行できていました。バージョンの表示と、もし入っていない場合はインストールする、というステップを追加しました。（インストール自体は試していません。 Copilot が書いてくれた内容をそのまま貼ったものです。）