### PR TITLE
handleFlashErrorStatus の修正と システムテストの追加

### DIFF
--- a/test/system/dummies_system_test.rb
+++ b/test/system/dummies_system_test.rb
@@ -10,4 +10,113 @@ class DummiesSystemTest < ActionDispatch::SystemTestCase
     assert_selector "h1", text: "Dummies#index"
     assert_selector "[data-testid='flash-message-display-here']"
   end
+
+  # Helper: read the layout timestamp shown in #time-current
+  def layout_timestamp
+    find('#time-current').text.strip
+  end
+
+  test "turbo drive: success flash shows and full page reloads" do
+    visit "/dummies"
+    before_time = layout_timestamp
+
+    click_on "Success flash"
+
+    # After a Turbo Drive redirect, the flash message should be rendered into the
+    # flash container and the layout timestamp should change (full navigation).
+    assert_selector '[data-flash-message-container] .flash-notice', text: 'Saved successfully'
+    after_time = layout_timestamp
+    assert_not_equal before_time, after_time, "Expected full page reload to change layout timestamp"
+  end
+
+  test "turbo drive: failure flash shows and full page reloads" do
+    visit "/dummies"
+    before_time = layout_timestamp
+
+    click_on "Failure flash"
+
+    # For failure route (render :index), the server returns the index template
+    # and the flash.now[:alert] should be rendered into the storage which the
+    # client picks up and shows. Since this is a regular response (not a frame),
+    # the page will be fully rendered and timestamp should change.
+    assert_selector '[data-flash-message-container] .flash-alert', text: 'Could not create.'
+    after_time = layout_timestamp
+    assert_not_equal before_time, after_time, "Expected full page render to change layout timestamp"
+  end
+
+  test "turbo frame: success shows flash and only frame updates" do
+    visit "/dummies"
+    before_time = layout_timestamp
+
+    # Click a link that targets the turbo frame
+    click_on "Success (frame)"
+
+  # Frame update should render flash into the visible flash container and NOT change the outer layout timestamp
+  assert_selector "[data-testid='flash-message-display-here'] .flash-notice", text: 'Saved successfully'
+    after_time = layout_timestamp
+    assert_equal before_time, after_time, "Expected only frame update, layout timestamp must remain unchanged"
+  end
+
+  test "turbo frame: failure shows flash and only frame updates" do
+    visit "/dummies"
+    before_time = layout_timestamp
+
+    click_on "Failure (frame)"
+
+  assert_selector "[data-testid='flash-message-display-here'] .flash-alert", text: 'Could not create.'
+    after_time = layout_timestamp
+    assert_equal before_time, after_time, "Expected only frame update, layout timestamp must remain unchanged"
+  end
+
+  test "network error: turbo:fetch-request-error shows general network message" do
+    visit "/dummies"
+
+    # The general errors list is rendered but hidden in the layout; read it using visible: :all
+    assert_selector '#general-error-messages', visible: :all
+
+    # Trigger a turbo:fetch-request-error event to simulate a fetch/network failure
+    page.execute_script(<<~JS)
+      const ev = new Event('turbo:fetch-request-error');
+      document.dispatchEvent(ev);
+    JS
+
+    # The client JS should pick the network message and append it as an alert
+    # into the visible flash message container
+    assert_selector "[data-testid='flash-message-display-here'] .flash-alert", text: "Network Error"
+  end
+
+  test "turbo:submit-end with undefined fetchResponse acts as network error" do
+    visit "/dummies"
+
+    # Read the network message from the hidden list
+    network_message = find('#general-error-messages li[data-status="network"]', visible: :all).text.strip
+
+    # Ensure any previous flash messages/storages are removed so the handler will add the network message
+    page.execute_script("document.querySelectorAll('[data-flash-storage]').forEach(e => e.remove())")
+    page.execute_script("document.getElementById('flash-storage').innerHTML = ''")
+    page.execute_script("document.querySelectorAll('[data-flash-message-container]').forEach(c => c.innerHTML = '')")
+
+    # Dispatch turbo:submit-end with no fetchResponse (undefined in detail)
+    page.execute_script(<<~JS)
+      const ev = new CustomEvent('turbo:submit-end', { detail: {} });
+      document.dispatchEvent(ev);
+    JS
+
+    assert_selector "[data-testid='flash-message-display-here'] .flash-alert", text: network_message
+  end
+
+  test "http error status: turbo:submit-end with 413 shows payload-too-large message" do
+    visit "/dummies"
+
+    # Ensure we have the 413 message available in the hidden general list
+    assert_selector '#general-error-messages li[data-status="413"]', visible: :all
+
+    # Dispatch turbo:submit-end with a fake fetchResponse having statusCode 413
+    page.execute_script(<<~JS)
+      const ev = new CustomEvent('turbo:submit-end', { detail: { fetchResponse: { statusCode: 413 } } });
+      document.dispatchEvent(ev);
+    JS
+
+    assert_selector "[data-testid='flash-message-display-here'] .flash-alert", text: "Payload Too Large"
+  end
 end


### PR DESCRIPTION
Rails に到達しない場合のエラーを出す際に使う関数 `handleFlashErrorStatus` の `status` に "network" が渡された時に、それを数値 ( < 400 など) と比較ができない問題を修正します。

加えて、システムテストを追加します。 Turbo Drive と Turbo Frame のテスト。 Turbo Stream のテストは TODO です。

---

This pull request improves the robustness of the flash message handling system, particularly around Turbo navigation events and error scenarios. It refactors the client-side logic for displaying general error messages based on HTTP status or network errors, and adds comprehensive system tests to verify correct flash behavior for full page reloads, Turbo frame updates, and error conditions.

**Flash message logic improvements:**

* Refactored the `handleFlashErrorStatus` function in `flash_unified.js` to more clearly handle network and HTTP error statuses, prevent duplicate messages, and provide better error logging when general error messages are missing.

**System test coverage:**

* Added extensive system tests in `dummies_system_test.rb` to verify that flash messages display correctly for Turbo Drive navigations, Turbo Frame updates, network errors, and specific HTTP error statuses. These tests assert both the presence of flash messages and the correct behavior of layout updates.

**Minor cleanup:**

* Removed a stray comment in `flash_unified.js` for clarity.