### PR TITLE
flash_unified.js リファクタリングとテスト追加

### DIFF
--- a/app/javascript/flash_unified/flash_unified.js
+++ b/app/javascript/flash_unified/flash_unified.js
@@ -246,24 +246,16 @@ function initializeFlashMessageSystem(debugFlag = false) {
     });
   })();
 
-  (function() {
-    let domLoaded = false;
+  // 初期描画: DOM 準備完了時に一度だけ実行 / Initial render once on DOM ready
+  if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', function() {
-      if (domLoaded) return;
-      domLoaded = true;
-      debugLog('DOMContentLoaded (initial load)');
+      debugLog('DOMContentLoaded');
       renderFlashMessages();
-    });
-
-    // If the document is already loaded (e.g. script loaded late), run once
-    if (document.readyState === "complete" || document.readyState === "interactive") {
-      if (!domLoaded) {
-        domLoaded = true;
-        debugLog('DOMContentLoaded (late init)');
-        renderFlashMessages();
-      }
-    }
-  })();
+    }, { once: true });
+  } else {
+    debugLog('DOMContentLoaded (immediate)');
+    renderFlashMessages();
+  }
 }
 
 /* フラッシュ・メッセージの表示をクリアします。

--- a/app/javascript/flash_unified/flash_unified.js
+++ b/app/javascript/flash_unified/flash_unified.js
@@ -345,7 +345,7 @@ function handleFlashErrorStatus(status) {
 
   // Avoid duplicates when container has children
   const container = document.querySelector('[data-flash-message-container]');
-  if (container && container.children.length > 0) return;
+  if (container && container.querySelector('[data-flash-message]')) return;
 
   const generalerrors = document.getElementById('general-error-messages');
   if (!generalerrors) {

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,5 +2,6 @@ require "test_helper"
 require "capybara/rails"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :rack_test
+  # Use cuprite driver to support JS execution in system tests
+  driven_by :cuprite_custom
 end

--- a/test/dummy/app/controllers/flash_pages_controller.rb
+++ b/test/dummy/app/controllers/flash_pages_controller.rb
@@ -1,0 +1,39 @@
+class FlashPagesController < ApplicationController
+  layout :resolve_layout
+
+  protect_from_forgery with: :null_session
+
+  def basic
+    flash.now[:alert] = 'Basic alert'
+    flash.now[:notice] = 'Basic notice'
+  end
+
+  def custom; end
+
+  def stream; end
+
+  def stream_update
+    flash.now[:notice] = 'From stream'
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.append(
+          'flash-storage',
+          partial: 'flash_unified/storage'
+        )
+      end
+      format.html { head :ok }
+    end
+  end
+
+  def events; end
+
+  def missing_template
+    flash.now[:warning] = 'Warn without template'
+  end
+
+  private
+
+  def resolve_layout
+    action_name == 'missing_template' ? 'flash_unified_test_nowarning' : 'flash_unified_test'
+  end
+end

--- a/test/dummy/app/views/flash_pages/basic.html.erb
+++ b/test/dummy/app/views/flash_pages/basic.html.erb
@@ -1,0 +1,3 @@
+<h1>Basic</h1>
+
+<%= flash_storage %>

--- a/test/dummy/app/views/flash_pages/custom.html.erb
+++ b/test/dummy/app/views/flash_pages/custom.html.erb
@@ -1,0 +1,15 @@
+<h1>Custom</h1>
+
+<button id="dispatch-custom">Dispatch custom</button>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('dispatch-custom').addEventListener('click', () => {
+      const detail = [
+        { type: 'notice', message: 'Custom A' },
+        { type: 'alert',  message: 'Custom B' }
+      ];
+      document.dispatchEvent(new CustomEvent('flash-unified:messages', { detail }));
+    });
+  });
+  
+</script>

--- a/test/dummy/app/views/flash_pages/events.html.erb
+++ b/test/dummy/app/views/flash_pages/events.html.erb
@@ -1,0 +1,18 @@
+<h1>Events</h1>
+
+<button id="simulate-network">Simulate network error</button>
+<button id="simulate-413">Simulate 413</button>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('simulate-network').addEventListener('click', () => {
+      document.dispatchEvent(new CustomEvent('turbo:fetch-request-error', { detail: {} }));
+    });
+    document.getElementById('simulate-413').addEventListener('click', () => {
+      document.dispatchEvent(new CustomEvent('turbo:submit-end', {
+        detail: { fetchResponse: { statusCode: 413 } }
+      }));
+    });
+  });
+  
+</script>

--- a/test/dummy/app/views/flash_pages/missing_template.html.erb
+++ b/test/dummy/app/views/flash_pages/missing_template.html.erb
@@ -1,0 +1,3 @@
+<h1>Missing template</h1>
+
+<%= flash_storage %>

--- a/test/dummy/app/views/flash_pages/stream.html.erb
+++ b/test/dummy/app/views/flash_pages/stream.html.erb
@@ -1,0 +1,3 @@
+<h1>Stream</h1>
+
+<%= button_to 'Add by stream', '/flash/stream_update', method: :post, data: { turbo: true } %>

--- a/test/dummy/app/views/layouts/flash_unified_test.html.erb
+++ b/test/dummy/app/views/layouts/flash_unified_test.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>FlashUnified Test</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "application" %>
+    <%= javascript_include_tag "turbo", type: "module" %>
+    <script type="module">
+      import { initializeFlashMessageSystem, renderFlashMessages } from "<%= asset_path('flash_unified/flash_unified.js') %>";
+      const init = () => { initializeFlashMessageSystem(); Promise.resolve().then(() => renderFlashMessages()); };
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+      } else {
+        init();
+      }
+    </script>
+  </head>
+  <body>
+    <%= flash_global_storage %>
+    <%= flash_templates %>
+    <%= flash_general_error_messages %>
+    <%= flash_container %>
+
+    <%= yield %>
+  </body>
+  </html>

--- a/test/dummy/app/views/layouts/flash_unified_test_nowarning.html.erb
+++ b/test/dummy/app/views/layouts/flash_unified_test_nowarning.html.erb
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>FlashUnified Test (no warning tmpl)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "application" %>
+    <%= javascript_include_tag "turbo", type: "module" %>
+    <script type="module">
+      import { initializeFlashMessageSystem, renderFlashMessages } from "<%= asset_path('flash_unified/flash_unified.js') %>";
+      const init = () => { initializeFlashMessageSystem(); Promise.resolve().then(() => renderFlashMessages()); };
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+      } else {
+        init();
+      }
+    </script>
+  </head>
+  <body>
+    <%= flash_global_storage %>
+    <%= flash_general_error_messages %>
+
+    <!-- Only notice and alert templates (warning intentionally omitted) -->
+    <template id="flash-message-template-notice">
+      <div class="flash-notice" role="alert"><span class="flash-message-text"></span></div>
+    </template>
+    <template id="flash-message-template-alert">
+      <div class="flash-alert" role="alert"><span class="flash-message-text"></span></div>
+    </template>
+
+    <%= flash_container %>
+    <%= yield %>
+  </body>
+  </html>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -12,6 +12,15 @@ Rails.application.routes.draw do
     end
   end
 
+  scope :flash do
+    get  'basic',            to: 'flash_pages#basic'
+    get  'custom',           to: 'flash_pages#custom'
+    get  'stream',           to: 'flash_pages#stream'
+    post 'stream_update',    to: 'flash_pages#stream_update'
+    get  'events',           to: 'flash_pages#events'
+    get  'missing_template', to: 'flash_pages#missing_template'
+  end
+
   # Defines the root path route ("/")
   root to: "home#index"
 end

--- a/test/system/flash_unified_pages_system_test.rb
+++ b/test/system/flash_unified_pages_system_test.rb
@@ -1,0 +1,40 @@
+require "application_system_test_case"
+
+class FlashUnifiedPagesSystemTest < ApplicationSystemTestCase
+  test "renders server-side storage on load" do
+    visit "/flash/basic"
+    assert_selector "[data-flash-message]", text: "Basic alert"
+    assert_selector "[data-flash-message]", text: "Basic notice"
+    assert_no_selector "[data-flash-storage]"
+  end
+
+  test "renders messages from custom event" do
+    visit "/flash/custom"
+    click_on "Dispatch custom"
+    assert_selector "[data-flash-message]", text: "Custom A"
+    assert_selector "[data-flash-message]", text: "Custom B"
+  end
+
+  test "renders messages from turbo stream append" do
+    visit "/flash/stream"
+    click_on "Add by stream"
+    assert_selector "[data-flash-message]", text: "From stream"
+  end
+
+  test "network error fallback uses general-error-messages" do
+    visit "/flash/events"
+    click_on "Simulate network error"
+    assert_selector "[data-flash-message]", text: I18n.t("http_status_messages.network")
+  end
+
+  test "submit-end 413 uses general-error-messages" do
+    visit "/flash/events"
+    click_on "Simulate 413"
+    assert_selector "[data-flash-message]", text: I18n.t("http_status_messages.413")
+  end
+
+  test "falls back when template missing" do
+    visit "/flash/missing_template"
+    assert_selector "[data-flash-message]", text: "Warn without template"
+  end
+end


### PR DESCRIPTION
flash_unified.js はだいぶ荒削りの状態であったので整理しました。
テストは js 自体のテストではなく、 js を組み込んだアプリをCapybaraで操作してDOMの様子を見るといったRailsのシステムテストです。

---
This pull request significantly improves the `flash_unified.js` flash message system by refactoring and enhancing its documentation, error handling, and event integration. It also introduces new system tests and controller/views in the test suite to verify flash message behavior. The most notable changes are grouped below.

**Flash Message System Improvements**

* Refactored and clarified the documentation at the top of `flash_unified.js`, providing a concise, bilingual (English/Japanese) minimal setup guide, clearer DOM structure requirements, and initialization instructions.
* Enhanced error handling and event integration:
  - Added support for handling Turbo Stream rendering events, network errors, and custom events for flash messages (`turbo:after-stream-render`, `turbo:submit-end`, `turbo:fetch-request-error`, and `flash-unified:messages`).
  - Improved fallback and error reporting for missing templates and error messages. [[1]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7L291-R313) [[2]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7R325-R336) [[3]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7L331-R367)
* Improved utility functions and code comments for clarity, including better handling of storage nodes, message duplication prevention, and idempotent initialization. [[1]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7L104-R72) [[2]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7R85-R101) [[3]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7L141-R126) [[4]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7L223-R266) [[5]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7L360-R383) [[6]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7L375-R403) [[7]](diffhunk://#diff-a6a91b969961cc69a41992a261a73920ba56cf5a6a9e451bf821cb4e4f1524d7L421)

**Testing Enhancements**

* Switched system test driver from `rack_test` to `cuprite_custom` in `ApplicationSystemTestCase` to enable JavaScript execution during system tests.
* Added a dedicated `FlashPagesController` and several test views (`basic`, `custom`, `stream`, `events`, `missing_template`) to the test dummy app for comprehensive flash message testing, including custom event dispatch and error simulation. [[1]](diffhunk://#diff-4acedf60cf05319c6b6e5c9e09e3bcc5ffa922270f023bbddb750ee27291c973R1-R39) [[2]](diffhunk://#diff-e275c663453a442c974acfe73a8b35967856bed273b59ebec5e8a6057f3ebff6R1-R3) [[3]](diffhunk://#diff-5a7aa752b01406089792339a90550a369491b98203a6e8bd7b84d02b6f8d7219R1-R15) [[4]](diffhunk://#diff-cd012a1ff847f79f17341081935e4d4f62abe571780a6f460a24b2c9194ffbacR1-R18)

These changes make the flash message system more robust, extensible, and easier to integrate and test in Rails applications.