### PR TITLE
test: add unit tests; improve CI to run per (ruby × appraisal)

### DIFF
--- a/.github/workflows/ci-fullset.yml
+++ b/.github/workflows/ci-fullset.yml
@@ -1,10 +1,12 @@
-name: CI
+name: CI - fullset
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-latest.yml
+++ b/.github/workflows/ci-latest.yml
@@ -16,7 +16,7 @@ on:
       appraisal:
         description: 'Appraisal name (gemfile key)'
         required: true
-        default: 'rails_8.0'
+        default: 'rails-8.0'
 
 jobs:
   latest:

--- a/.github/workflows/ci-latest.yml
+++ b/.github/workflows/ci-latest.yml
@@ -1,0 +1,37 @@
+name: CI - latest combo
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+    inputs:
+      ruby:
+        description: 'Ruby version'
+        required: true
+        default: '3.3'
+      appraisal:
+        description: 'Appraisal name (gemfile key)'
+        required: true
+        default: 'rails_8.0'
+
+jobs:
+  latest:
+    name: Run bin/test on latest combo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ github.event.inputs.ruby }}
+          bundler-cache: true
+      - name: Install gems for appraisal
+        run: |
+          bundle exec appraisal "${{ github.event.inputs.appraisal }}" bundle install --jobs 1 --retry 2
+      - name: Run bin/test
+        run: |
+          APPRAISAL="${{ github.event.inputs.appraisal }}" bin/test

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: [3.3]
-        appraisal: [rails_8.0]
+        appraisal: [rails-8.0]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ruby

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -1,0 +1,32 @@
+name: CI - unit
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    name: Unit tests (matrix)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [3.3]
+        appraisal: [rails_8.0]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Install gems for appraisal
+        run: |
+          bundle exec appraisal "${{ matrix.appraisal }}" bundle install --jobs 1 --retry 2
+      - name: Run unit tests only
+        run: |
+          APPRAISAL="${{ matrix.appraisal }}" bin/test unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,51 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  unit-tests:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    strategy:
-      matrix:
-        ruby: [3.2, 3.3]
-      # limit parallel matrix cells to avoid overwhelming rubygems.org
-      max-parallel: 2
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Compute Gemfile hash
-        id: gemfile_hash
-        run: |
-          # compute hash of Gemfile to use in cache key
-          if [ -f Gemfile ]; then echo "hash=$(sha1sum Gemfile | awk '{print $1}')" >> "$GITHUB_OUTPUT"; else echo "hash=missing" >> "$GITHUB_OUTPUT"; fi
-
-      - name: Cache Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ steps.gemfile_hash.outputs.hash }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ matrix.ruby }}-
-
-      - name: Ensure no Gemfile.lock influence
-        run: |
-          # Remove any checked-in Gemfile.lock to force fresh resolution in CI
-          if [ -f Gemfile.lock ]; then git rm -f --ignore-unmatch Gemfile.lock || true; fi
-
-      - name: Install dependencies (fresh)
-        run: |
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local without 'production'
-          bundle install --jobs 1 --retry 2
-
-      - name: Run unit tests
-        run: bundle exec rake test:unit
-
   generate-appraisals:
     name: Generate Appraisals list
     runs-on: ubuntu-latest
@@ -84,80 +39,37 @@ jobs:
           JSON=$(printf '%s\n' "$APPS" | awk 'NF{gsub(/"/,"\\\""); printf "%s\"%s\"", sep, $0; sep=","} END{print ""}')
           echo "appraisals=[$JSON]" >> "$GITHUB_OUTPUT"
 
-  generator-tests:
-    name: Generator tests
+  all-tests:
+    name: All tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
+    needs: generate-appraisals
     strategy:
       matrix:
         ruby: [3.2, 3.3]
         appraisal: ${{ fromJson(needs.generate-appraisals.outputs.appraisals) }}
       # limit parallel matrix cells to avoid overwhelming rubygems.org
       max-parallel: 2
-    needs: generate-appraisals
     env:
       APPRAISAL: ${{ matrix.appraisal }}
     steps:
       - uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - name: Install dependencies (fresh)
+      - name: Ensure no Gemfile.lock influence
         run: |
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local without 'production'
-          bundle install --jobs 1 --retry 2
+          # Remove any checked-in Gemfile.lock to force fresh resolution in CI
+          if [ -f Gemfile.lock ]; then git rm -f --ignore-unmatch Gemfile.lock || true; fi
 
-      - name: Install appraisal gemfiles
+      - name: Warm selected appraisal dependencies
         run: |
-          bundle exec appraisal install
-
-      - name: Cache Ruby gems (generator appraisal)
-        uses: actions/cache@v4
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.appraisal }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.appraisal }}-
-            ${{ runner.os }}-gems-${{ matrix.ruby }}-
-
-      - name: Run generator tests via helper (suite-first)
-        run: |
-          echo "Running generators with APPRAISAL='${APPRAISAL}' (matrix='${{ matrix.appraisal }}')"
-          bin/test generators
-
-  system-tests:
-    name: System tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        ruby: [3.2]
-        appraisal: ${{ fromJson(needs.generate-appraisals.outputs.appraisals) }}
-      max-parallel: 2
-    needs: generate-appraisals
-    env:
-      APPRAISAL: ${{ matrix.appraisal }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Install dependencies (fresh)
-        run: |
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local without 'production'
-          bundle install --jobs 1 --retry 2
-
-      - name: Install appraisal gemfiles
-        run: |
-          bundle exec appraisal install
+          echo "Installing gems for APPRAISAL='${APPRAISAL}'"
+          bundle exec appraisal "${APPRAISAL}" bundle install --jobs 1 --retry 2
 
       - name: Check installed browser (install if missing)
         run: |
@@ -171,7 +83,7 @@ jobs:
             sudo apt-get install -y chromium-browser --no-install-recommends
           fi
 
-      - name: Run system tests via helper (suite-first)
+      - name: Run all tests via helper
         run: |
-          echo "Running system with APPRAISAL='${APPRAISAL}' (matrix='${{ matrix.appraisal }}')"
-          bin/test system
+          echo "Running all tests with APPRAISAL='${APPRAISAL}' (matrix='${{ matrix.appraisal }}', ruby='${{ matrix.ruby }}')"
+          bin/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,9 @@ jobs:
             ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.appraisal }}-
             ${{ runner.os }}-gems-${{ matrix.ruby }}-
 
-      - name: Run generator tests under appraisal
+      - name: Run generator tests via helper (suite-first)
         run: |
-          bundle exec appraisal ${APPRAISAL} rake test:generators
+          bin/run-dummy-tests generators ${APPRAISAL}
 
   system-tests:
     name: System tests (Appraisal matrix)
@@ -171,6 +171,6 @@ jobs:
             sudo apt-get install -y chromium-browser --no-install-recommends
           fi
 
-      - name: Run dummy system test under appraisal
+      - name: Run system tests via helper (suite-first)
         run: |
-          bundle exec appraisal ${APPRAISAL} rake test:system
+          bin/run-dummy-tests system ${APPRAISAL}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Run generator tests via helper (suite-first)
         run: |
-          bin/run-dummy-tests generators ${APPRAISAL}
+          bin/test generators ${APPRAISAL}
 
   system-tests:
     name: System tests (Appraisal matrix)
@@ -173,4 +173,4 @@ jobs:
 
       - name: Run system tests via helper (suite-first)
         run: |
-          bin/run-dummy-tests system ${APPRAISAL}
+          bin/test system ${APPRAISAL}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   unit-tests:
-    name: Unit tests (fresh resolve)
+    name: Unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 3
     strategy:
@@ -24,9 +24,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
-      - name: Install bundler
-        run: gem install bundler
 
       - name: Compute Gemfile hash
         id: gemfile_hash
@@ -63,24 +60,32 @@ jobs:
       appraisals: ${{ steps.generate.outputs.appraisals }}
     steps:
       - uses: actions/checkout@v4
-      - name: Generate appraisals JSON
-        id: generate
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+      - name: Install dependencies (fresh)
         run: |
-          # parse Appraisals file for lines like: appraise 'rails-7.1' do
-          if [ ! -f Appraisals ]; then
-            echo "Appraisals file not found" >&2
+          bundle config set --local path 'vendor/bundle'
+          bundle config set --local without 'production'
+          bundle install --jobs 1 --retry 2
+      - name: Generate appraisals JSON from `appraisal list`
+        id: generate
+        shell: bash
+        run: |
+          set -euo pipefail
+          APPS=$(bundle exec appraisal list || true)
+          if [ -z "${APPS}" ]; then
+            echo "ERROR: 'appraisal list' returned no entries" >&2
             exit 2
           fi
-          # Extract the second single-quoted field from lines starting with appraise
-          APP_LIST=$(awk -F"'" '/^appraise[[:space:]]+('\''|")/ {printf "%s\"%s\"",sep,$2; sep=","} END{print ""}' Appraisals)
-          if [ -z "$APP_LIST" ]; then
-            echo "No appraisals found in Appraisals file" >&2
-            exit 2
-          fi
-          echo "appraisals=[$APP_LIST]" >> "$GITHUB_OUTPUT"
+          # Build JSON array safely without jq
+          JSON=$(printf '%s\n' "$APPS" | awk 'NF{gsub(/"/,"\\\""); printf "%s\"%s\"", sep, $0; sep=","} END{print ""}')
+          echo "appraisals=[$JSON]" >> "$GITHUB_OUTPUT"
 
   generator-tests:
-    name: Generator tests (Rails matrix, fresh resolve)
+    name: Generator tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -99,9 +104,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
-      - name: Install bundler
-        run: gem install bundler
 
       - name: Install dependencies (fresh)
         run: |
@@ -124,10 +126,11 @@ jobs:
 
       - name: Run generator tests via helper (suite-first)
         run: |
-          bin/test generators ${APPRAISAL}
+          echo "Running generators with APPRAISAL='${APPRAISAL}' (matrix='${{ matrix.appraisal }}')"
+          bin/test generators
 
   system-tests:
-    name: System tests (Appraisal matrix)
+    name: System tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -145,9 +148,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
-      - name: Install bundler
-        run: gem install bundler
 
       - name: Install dependencies (fresh)
         run: |
@@ -173,4 +173,5 @@ jobs:
 
       - name: Run system tests via helper (suite-first)
         run: |
-          bin/test system ${APPRAISAL}
+          echo "Running system with APPRAISAL='${APPRAISAL}' (matrix='${{ matrix.appraisal }}')"
+          bin/test system

--- a/DEVELOPMENT.ja.md
+++ b/DEVELOPMENT.ja.md
@@ -20,7 +20,7 @@
 | 複数 Rails 互換性 | Appraisals 導入済み | `Appraisals`、`bundle exec appraisal ...` |
 | CI（GitHub Actions） | 導入済み | `.github/workflows/ci.yml` |
 | サンドボックス | 手元検証用アプリを生成（Importmap/Propshaft/Sprockets） | `bin/sandbox`（テンプレ: `sandbox/templates/*.rb`） |
-| 補助スクリプト | Appraisals を横断して unit / generators / system を実行（スイート先行 CLI。既定は両方 all） | `bin/run-dummy-tests` |
+| 補助スクリプト | Appraisals を横断して unit / generators / system を実行（スイート先行 CLI。既定は両方 all） | `bin/test` |
 
 ## 2. ファイル構成
 
@@ -47,34 +47,34 @@ bundle exec appraisal install
 2) テストの実行
 
 ```bash
-bin/run-dummy-tests
+bin/test
 ```
 
 備考:
-- Rails が必要なテストは Appraisals を使って実行します。 `bin/run-dummy-tests` は各バージョンの Rails を用いて unit / generators / system を横断実行するためのラッパーです。
+- Rails が必要なテストは Appraisals を使って実行します。 `bin/test` は各バージョンの Rails を用いて unit / generators / system を横断実行するためのラッパーです。
 
 ## 4. テストの実行方法
 
 テストは目的ごとに個別に実行できます（スイート先行 CLI）。
 
-シグネチャ: `bin/run-dummy-tests [suite] [appraisal]`
+シグネチャ: `bin/test [suite] [appraisal]`
 
 ```
 # すべての Appraisals で全スイート（既定）
-bin/run-dummy-tests
+bin/test
 
 # すべての Appraisals で特定スイートのみ
-bin/run-dummy-tests unit
-bin/run-dummy-tests generators
-bin/run-dummy-tests system
+bin/test unit
+bin/test generators
+bin/test system
 
 # 特定の Appraisal で全スイート
-bin/run-dummy-tests all rails-7.2
+bin/test all rails-7.2
 
 # 特定の Appraisal で特定スイート
-bin/run-dummy-tests unit rails-7.2
-bin/run-dummy-tests generators rails-7.2
-bin/run-dummy-tests system rails-7.2
+bin/test unit rails-7.2
+bin/test generators rails-7.2
+bin/test system rails-7.2
 
 # ユニットテストのみ（現在の Gemfile 使用）
 bundle exec rake test:unit
@@ -95,7 +95,7 @@ bundle exec appraisal rails-7.2 rake test TEST=test/system/target_test.rb
 
 cuprite の設定として、環境変数 `HEADLESS` に `0` をセットするとヘッドレス・モードを解除します。また `SLOWMO` に秒数をセットすると、ステップごとにその秒数のディレイが入ります。これらを合わせて指定すると、ブラウザの実際の操作の様子を観察できます：
 ```
-HEADLESS=0 SLOWMO=0.3 bin/run-dummy-tests system rails-7.2
+HEADLESS=0 SLOWMO=0.3 bin/test system rails-7.2
 ```
 
 ## 5. ダミーアプリとサンドボックス

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ This guide helps new contributors get started quickly and safely. It summarizes 
 | Multi-Rails compatibility | Appraisals in place (Rails 7.1.5.2 / 7.2.2.2 / 8.0.3) | `Appraisals`, `bundle exec appraisal ...` |
 | CI (GitHub Actions) | In place | `.github/workflows/ci.yml` (jobs: unit-tests〈Ruby 3.2/3.3〉, generate-appraisals, generator-tests〈Appraisals matrix〉, system-tests〈Appraisals matrix〉) |
 | Sandbox | Generate local apps for quick checks (Importmap/Propshaft/Sprockets) | `bin/sandbox` (templates: `sandbox/templates/*.rb`) |
-| Helper script | Run unit/generator/system across Appraisals. Suite-first CLI; defaults: `suite=all`, `appraisal=all` | `bin/run-dummy-tests` |
+| Helper script | Run unit/generator/system across Appraisals. Suite-first CLI; defaults: `suite=all`, `appraisal=all` | `bin/test` |
 
 ## 2. Repository layout
 
@@ -47,34 +47,34 @@ bundle exec appraisal install
 2) Run tests
 
 ```bash
-bin/run-dummy-tests
+bin/test
 ```
 
 Notes:
-- Tests requiring specific Rails variants run via Appraisals. `bin/run-dummy-tests` is a convenience wrapper to execute unit / generator / system tests across defined Appraisals.
+- Tests requiring specific Rails variants run via Appraisals. `bin/test` is a convenience wrapper to execute unit / generator / system tests across defined Appraisals.
 
 ## 4. How to run tests (by purpose)
 
 Run suites separately for clarity and speed.
 
-Signature: `bin/run-dummy-tests [suite] [appraisal]`
+Signature: `bin/test [suite] [appraisal]`
 
 ```
 # All suites across all Appraisals (default)
-bin/run-dummy-tests
+bin/test
 
 # Specific suite across all Appraisals
-bin/run-dummy-tests unit
-bin/run-dummy-tests generators
-bin/run-dummy-tests system
+bin/test unit
+bin/test generators
+bin/test system
 
 # All suites on a specific Appraisal
-bin/run-dummy-tests all rails-7.2
+bin/test all rails-7.2
 
 # Specific suite on a specific Appraisal
-bin/run-dummy-tests unit rails-7.2
-bin/run-dummy-tests generators rails-7.2
-bin/run-dummy-tests system rails-7.2
+bin/test unit rails-7.2
+bin/test generators rails-7.2
+bin/test system rails-7.2
 
 # Unit only using current Gemfile
 bundle exec rake test:unit
@@ -97,7 +97,7 @@ For system tests that require JavaScript, the Capybara driver uses cuprite, so a
 With cuprite, if you set the environment variable `HEADLESS=0`, tests will run in non-headless mode. You can also set `SLOWMO` to a number of seconds to add a delay between steps. Combining these allows you to observe browser actions visually:
 
 ```
-HEADLESS=0 SLOWMO=0.3 bin/run-dummy-tests system rails-7.2
+HEADLESS=0 SLOWMO=0.3 bin/test system rails-7.2
 ```
 
 ## 5. Dummy app vs Sandbox
@@ -121,4 +121,3 @@ HEADLESS=0 SLOWMO=0.3 bin/run-dummy-tests system rails-7.2
 - Enrich generator tests (assert duplicate-prevention and content details).
 - Introduce a minimal JS unit-test layer when it adds clear value (e.g., jsdom + vitest).
 - Add representative system scenarios (Turbo Frame/Stream basics) as the next step.
-

--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,8 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
 
-  # Run only unit-level tests by default (pure Ruby, no Rails boot).
-  # Use TEST=... for ad-hoc files, or rake test:generators / test:system for other layers.
+  # Run unit-layer tests by default. Use TEST=... for ad-hoc files,
+  # or rake test:generators / test:system for other layers.
   t.test_files = FileList[
     "test/unit/**/*_test.rb",
     "test/lib/**/*_test.rb"
@@ -23,8 +23,7 @@ namespace :test do
   Rake::TestTask.new(:unit) do |t|
     t.libs << "test"
     t.libs << "lib"
-    # Explicitly include unit-layer tests only (pure Ruby, no Rails boot).
-    # Do not include top-level tests here, as some require test_helper (Rails).
+    # Explicitly include unit-layer tests only.
     t.test_files = FileList[
       "test/unit/**/*_test.rb",
       "test/lib/**/*_test.rb"
@@ -35,8 +34,7 @@ namespace :test do
   Rake::TestTask.new(:generators) do |t|
     t.libs << "test"
     t.libs << "lib"
-    # Scope strictly to generator tests. These intentionally load test/test_helper
-    # (which boots the dummy app) to exercise Rails::Generators behavior.
+    # Scope strictly to generator tests.
     t.test_files = FileList[
       "test/generators/**/*_test.rb"
     ]

--- a/bin/run-dummy-tests
+++ b/bin/run-dummy-tests
@@ -2,37 +2,57 @@
 set -euo pipefail
 
 # Run dummy app tests across Appraisals using rake tasks.
+# New CLI (breaking change): SUITE first, then Rails version (Appraisal)
 # Usage:
-#   bin/run-dummy-tests [appraisal|all] [suite]
-#   suite: system (default) | generators
+#   bin/run-dummy-tests [suite] [appraisal]
+#     - Both args default to 'all' when omitted
+#     - Suite is required when specifying an appraisal (suite-first CLI)
+#   suite: system | generators | unit | all
+#   appraisal: rails-7.1 | rails-7.2 | rails-8.0 | all
 # Examples:
-#   bin/run-dummy-tests                     # runs system tests for all appraisals
-#   bin/run-dummy-tests rails-7.1           # system tests for only rails-7.1
-#   bin/run-dummy-tests all generators      # generator tests for all appraisals
+#   bin/run-dummy-tests                     # runs all suites for all appraisals (default)
+#   bin/run-dummy-tests all all             # explicit: all suites × all appraisals
+#   bin/run-dummy-tests system              # system tests for all appraisals
+#   bin/run-dummy-tests generators rails-7.1
+#   bin/run-dummy-tests unit all
+#   bin/run-dummy-tests all rails-7.2
 
-REQUESTED=${1:-all}
-SUITE=${2:-system}
+SUITE=${1:-all}
+REQUESTED=${2:-all}
 
 usage() {
   cat <<USAGE
-    Usage: $(basename "$0") [appraisal|all] [suite]
-      suite: system (default) | generators
+    Usage: $(basename "$0") [suite] [appraisal]
+      - Both args default to 'all' when omitted
+      - Suite is required when specifying an appraisal (suite-first CLI)
+      suite: system | generators | unit | all
+      appraisal: rails-7.1 | rails-7.2 | rails-8.0 | all
     Examples:
       $(basename "$0")
-      $(basename "$0") rails-7.1
-      $(basename "$0") all
-      $(basename "$0") all generators
+      $(basename "$0") all all
+      $(basename "$0") system
+      $(basename "$0") generators rails-7.1
+      $(basename "$0") unit all
+      $(basename "$0") all rails-7.2
 USAGE
 }
 
-if [[ "$REQUESTED" == "-h" || "$REQUESTED" == "--help" ]]; then
+if [[ "$SUITE" == "-h" || "$SUITE" == "--help" ]]; then
   usage
   exit 0
 fi
 
+# Friendly guard: if the first argument looks like an appraisal, remind about suite-first order
+if [[ "$SUITE" =~ ^rails-[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: You specified an appraisal without a suite. This CLI is suite-first." >&2
+  echo "       Use: $(basename "$0") [suite] [appraisal]  (e.g., '$(basename "$0") system $SUITE')" >&2
+  usage
+  exit 2
+fi
+
 # Validate suite
 case "$SUITE" in
-  system|generators)
+  system|generators|unit|all)
     ;;
   *)
     echo "Unknown suite: $SUITE" >&2
@@ -41,7 +61,11 @@ case "$SUITE" in
     ;;
 esac
 
-TASK="test:$SUITE"
+if [[ "$SUITE" == "all" ]]; then
+  SUITES=(unit generators system)
+else
+  SUITES=($SUITE)
+fi
 
 # Read Appraisals from `bundle exec appraisal list`. Fail fast if the command isn't available or returns no appraisals.
 if ! command -v bundle >/dev/null 2>&1; then
@@ -76,13 +100,13 @@ if [[ "$REQUESTED" != "all" ]]; then
     fi
   done
   if [[ "$FOUND" == false ]]; then
-    echo "Unknown appraisal: $REQUESTED"
+    echo "Unknown appraisal (Rails version): $REQUESTED"
     echo "Supported: ${APPRAISALS[*]}"
     exit 2
   fi
 fi
 
-echo "Running dummy $SUITE tests for appraisals: ${APPRAISALS[*]}"
+echo "Running $SUITE suite(s) for appraisals: ${APPRAISALS[*]}"
 
 for a in "${APPRAISALS[@]}"; do
   echo
@@ -91,8 +115,11 @@ for a in "${APPRAISALS[@]}"; do
   # echo "Preparing dummy DB for $a..."
   # bundle exec appraisal "$a" bash -lc "cd test/dummy && bundle exec rake db:drop db:create db:migrate RAILS_ENV=test"
 
-  echo "Running $SUITE tests for $a via 'rake ${TASK}'..."
-  bundle exec appraisal "$a" rake "${TASK}"
+  for s in "${SUITES[@]}"; do
+    TASK="test:${s}"
+    echo "Running ${s} tests for $a via 'rake ${TASK}'..."
+    bundle exec appraisal "$a" rake "${TASK}"
+  done
 
   echo "=== Finished $a ==="
 done

--- a/bin/test
+++ b/bin/test
@@ -18,7 +18,16 @@ set -euo pipefail
 #   bin/test all rails-7.2
 
 SUITE=${1:-all}
-REQUESTED=${2:-all}
+# Default requested appraisal to $APPRAISAL when provided (e.g., in CI), otherwise 'all'
+REQUESTED=${2:-${APPRAISAL:-all}}
+
+# Minimal logging to help CI: show selected suite and appraisal
+echo "Params: SUITE='${SUITE}' REQUESTED='${REQUESTED}' APPRAISAL='${APPRAISAL:-}'"
+
+# Defensive fallback: if REQUESTED is still 'all' but APPRAISAL is set, prefer the env (CI safety)
+if [[ "$REQUESTED" == "all" && -n "${APPRAISAL:-}" ]]; then
+  REQUESTED="$APPRAISAL"
+fi
 
 usage() {
   cat <<USAGE

--- a/bin/test
+++ b/bin/test
@@ -4,36 +4,37 @@ set -euo pipefail
 # Run dummy app tests across Appraisals using rake tasks.
 # New CLI (breaking change): SUITE first, then Rails version (Appraisal)
 # Usage:
-#   bin/run-dummy-tests [suite] [appraisal]
+#   bin/test [suite] [appraisal]
 #     - Both args default to 'all' when omitted
 #     - Suite is required when specifying an appraisal (suite-first CLI)
 #   suite: system | generators | unit | all
 #   appraisal: rails-7.1 | rails-7.2 | rails-8.0 | all
 # Examples:
-#   bin/run-dummy-tests                     # runs all suites for all appraisals (default)
-#   bin/run-dummy-tests all all             # explicit: all suites × all appraisals
-#   bin/run-dummy-tests system              # system tests for all appraisals
-#   bin/run-dummy-tests generators rails-7.1
-#   bin/run-dummy-tests unit all
-#   bin/run-dummy-tests all rails-7.2
+#   bin/test                     # runs all suites for all appraisals (default)
+#   bin/test all all             # explicit: all suites × all appraisals
+#   bin/test system              # system tests for all appraisals
+#   bin/test generators rails-7.1
+#   bin/test unit all
+#   bin/test all rails-7.2
 
 SUITE=${1:-all}
 REQUESTED=${2:-all}
 
 usage() {
   cat <<USAGE
-    Usage: $(basename "$0") [suite] [appraisal]
-      - Both args default to 'all' when omitted
-      - Suite is required when specifying an appraisal (suite-first CLI)
-      suite: system | generators | unit | all
-      appraisal: rails-7.1 | rails-7.2 | rails-8.0 | all
-    Examples:
-      $(basename "$0")
-      $(basename "$0") all all
-      $(basename "$0") system
-      $(basename "$0") generators rails-7.1
-      $(basename "$0") unit all
-      $(basename "$0") all rails-7.2
+Usage: $(basename "$0") [suite] [appraisal]
+  - Both args default to 'all' when omitted
+  - Suite is required when specifying an appraisal (suite-first CLI)
+  suite: system | generators | unit | all
+  appraisal: rails-7.1 | rails-7.2 | rails-8.0 | all
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") all all
+  $(basename "$0") system
+  $(basename "$0") generators rails-7.1
+  $(basename "$0") unit all
+  $(basename "$0") all rails-7.2
 USAGE
 }
 

--- a/test/unit/engine_test.rb
+++ b/test/unit/engine_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class EngineInitializationTest < Minitest::Test
+  def test_view_helper_is_included_into_action_controller
+    # Use the public API: ActionController::Base.helpers returns a view context
+    # proxy that should respond to helper methods when included.
+    helpers = ActionController::Base.helpers
+    assert_respond_to helpers, :flash_container
+    assert_respond_to helpers, :flash_templates
+    assert_respond_to helpers, :flash_storage
+    assert_respond_to helpers, :flash_global_storage
+    assert_respond_to helpers, :flash_general_error_messages
+  end
+end

--- a/test/unit/locales_test.rb
+++ b/test/unit/locales_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class LocalesTest < Minitest::Test
+  def test_http_status_messages_keys_exist
+    I18n.with_locale(:en) do
+      assert I18n.exists?('http_status_messages.network'), 'network message should exist'
+      assert I18n.exists?('http_status_messages.413'), '413 message should exist'
+      assert_equal 'Payload Too Large', I18n.t('http_status_messages.413')
+      assert_equal 'Network Error', I18n.t('http_status_messages.network')
+    end
+  end
+end

--- a/test/unit/view_helper_test.rb
+++ b/test/unit/view_helper_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class FlashUnifiedViewHelperTest < ActionView::TestCase
+  tests FlashUnified::ViewHelper
+
+  test 'flash_container renders container marker' do
+    html = flash_container
+    assert_includes html, 'data-flash-message-container'
+  end
+
+  test 'flash_global_storage renders global storage id' do
+    html = flash_global_storage
+    assert_includes html, 'id="flash-storage"'
+  end
+
+  test 'flash_templates renders required templates' do
+    html = flash_templates
+    assert_includes html, 'template id="flash-message-template-notice"'
+    assert_includes html, 'template id="flash-message-template-alert"'
+    assert_includes html, 'class="flash-message-text"'
+  end
+
+  test 'flash_general_error_messages contains network key' do
+    html = flash_general_error_messages
+    assert_includes html, 'id="general-error-messages"'
+    assert_includes html, 'li data-status="network"'
+  end
+
+  test 'flash_storage renders storage wrapper even without flash' do
+    # flash が空でも最低限の枠が出力されること
+    html = flash_storage
+    assert_includes html, 'data-flash-storage'
+    assert_includes html, '<ul>'
+  end
+
+  test 'flash_storage renders li for flash entries' do
+    # ActionView::TestCase では controller の flash を使える
+    @controller.flash[:notice] = 'Hello'
+    html = flash_storage
+    assert_includes html, 'data-type="notice"'
+    assert_includes html, 'Hello'
+  end
+end


### PR DESCRIPTION
unit テストの追加が主目的でしたが、派生して CI の修正も行なっており、 unit / generators / system 各テストをすべてのマトリクス ruby [3.2, 3.3] x rails [7.1, 7.2, 8.0] で実行するように改めます。

実行するバッチコマンドの名称も変更しました。

---

This pull request makes several improvements to the test infrastructure and documentation, focusing on unifying test execution, modernizing the CI workflow, and clarifying test instructions for contributors. The most significant changes are the introduction of a new `bin/test` helper script for running all test suites across Appraisals, consolidation of CI jobs, and the addition of new unit tests for better coverage.

**Test infrastructure and CI workflow modernization:**

* Replaces multiple separate CI jobs (`unit-tests`, `generator-tests`, `system-tests`) with a unified `all-tests` job that runs all test suites (unit, generators, system) across a Ruby/Appraisal matrix using the new `bin/test` helper script. This simplifies the workflow and ensures consistent test execution. (.github/workflows/ci.yml) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL11-R72) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL174-R89)
* Adds a new step to generate the list of Appraisals dynamically via `bundle exec appraisal list`, improving maintainability and accuracy of matrix builds. (.github/workflows/ci.yml)

**Documentation and developer experience:**

* Updates both English (`DEVELOPMENT.md`) and Japanese (`DEVELOPMENT.ja.md`) contributor guides to document the new `bin/test` script, its usage, and test suite organization. The guides now explain running all, individual, or Appraisal-scoped test suites, and provide updated examples for running system tests with cuprite. [[1]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL16-R23) [[2]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL47-R91) [[3]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL92-R100) [[4]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL116) [[5]](diffhunk://#diff-579f39145477936823592a2228981105362fd1f22ec0745b66b9505c6e7b3fb5L18-R23) [[6]](diffhunk://#diff-579f39145477936823592a2228981105362fd1f22ec0745b66b9505c6e7b3fb5L47-R84) [[7]](diffhunk://#diff-579f39145477936823592a2228981105362fd1f22ec0745b66b9505c6e7b3fb5L90-R98)
* Clarifies Rake test task comments and removes outdated notes about Rails boot requirements, reflecting the new unified approach. (`Rakefile`) [[1]](diffhunk://#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0fL8-R9) [[2]](diffhunk://#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0fL26-R26) [[3]](diffhunk://#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0fL38-R37)

**Test coverage improvements:**

* Adds new unit tests for engine initialization, locale keys, and view helpers to ensure critical integrations and helper methods are properly tested. (`test/unit/engine_test.rb`, `test/unit/locales_test.rb`, `test/unit/view_helper_test.rb`) [[1]](diffhunk://#diff-9a2ee5509aba42c8bd82af6fa302e053a870ec9c9f848462bcfc5f60df1af768R1-R14) [[2]](diffhunk://#diff-3141a2584c5c2787acac71acb8245ea8b3f414cc3aa730ff63784281c58fa616R1-R12) [[3]](diffhunk://#diff-99563863039386fe3ad505e75e49d7311d73c5ee5af4ece462ad1f2393cf22bfR1-R43)