### PR TITLE
Workflow Restructuring and Renaming

### DIFF
--- a/.github/workflows/ci-fullset.yml
+++ b/.github/workflows/ci-fullset.yml
@@ -1,16 +1,12 @@
-name: CI
+name: CI - fullset
 
 concurrency:
-  # Group by workflow name and the pull request number when present, otherwise the branch ref.
-  # This ensures older runs for the same PR/branch are cancelled when a new run starts.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:
   push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-latest.yml
+++ b/.github/workflows/ci-latest.yml
@@ -1,0 +1,37 @@
+name: CI - latest combo
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+    inputs:
+      ruby:
+        description: 'Ruby version'
+        required: true
+        default: '3.3'
+      appraisal:
+        description: 'Appraisal name (gemfile key)'
+        required: true
+        default: 'rails_8.0'
+
+jobs:
+  latest:
+    name: Run bin/test on latest combo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ github.event.inputs.ruby }}
+          bundler-cache: true
+      - name: Install gems for appraisal
+        run: |
+          bundle exec appraisal "${{ github.event.inputs.appraisal }}" bundle install --jobs 1 --retry 2
+      - name: Run bin/test
+        run: |
+          APPRAISAL="${{ github.event.inputs.appraisal }}" bin/test

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -1,0 +1,32 @@
+name: CI - unit
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    name: Unit tests (matrix)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [3.3]
+        appraisal: [rails_8.0]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Install gems for appraisal
+        run: |
+          bundle exec appraisal "${{ matrix.appraisal }}" bundle install --jobs 1 --retry 2
+      - name: Run unit tests only
+        run: |
+          APPRAISAL="${{ matrix.appraisal }}" bin/test unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
 
+concurrency:
+  # Group by workflow name and the pull request number when present, otherwise the branch ref.
+  # This ensures older runs for the same PR/branch are cancelled when a new run starts.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ develop ]


### PR DESCRIPTION
CI によるテスト実行時のリソース浪費を懸念して、実行範囲（どのテストを、どのマトリクスで、どのタイミングに）を設計しました。

基本方針：
- PR のレビューは軽量で素早く：PR 作成 → 自動で `ci-unit`（unit テスト）だけを実行し、まずはここでかんたんなチェック
- develop (開発中の統合ブランチ)：develop にマージされたら `ci-latest`（最新 Ruby×Rails の bin/test）で最新版の対応を保証
- main (リリース直前の最終チェック)：main にマージされたら `ci-fullset`（フルセット）で総合検証

運用を簡単にするため、当面は専用のラベル（ラベルをつけることでの起動）や複雑な権限チェックは導入しません。

---

This pull request restructures our GitHub Actions CI workflows to improve clarity, flexibility, and efficiency. The old monolithic CI workflow is split into more focused jobs, with improved concurrency handling to avoid redundant runs. The main changes are as follows:

**Workflow Restructuring and Renaming:**

* The original `.github/workflows/ci.yml` has been renamed to `.github/workflows/ci-fullset.yml`, and its branch triggers are updated to run only on `main` instead of `develop`. The workflow name is also changed to "CI - fullset". Concurrency controls are added to prevent overlapping runs.

**Addition of New Workflows:**

* A new workflow `.github/workflows/ci-latest.yml` ("CI - latest combo") is introduced to test the latest Ruby and Rails combinations on pushes to `develop` and via manual dispatch, with user-configurable Ruby and appraisal versions. Concurrency controls are included.
* Another new workflow `.github/workflows/ci-unit.yml` ("CI - unit") is added to run unit tests in a matrix (currently Ruby 3.3 and Rails 8.0) on pull requests targeting `develop` and via manual dispatch, with concurrency management.