### PR TITLE
CI: Fix appraisal version specification

### DIFF
--- a/.github/workflows/ci-fullset.yml
+++ b/.github/workflows/ci-fullset.yml
@@ -85,7 +85,7 @@ jobs:
             sudo apt-get install -y chromium-browser --no-install-recommends
           fi
 
-      - name: Run all tests via helper
+      - name: Run bin/test
         run: |
           echo "Running all tests with APPRAISAL='${APPRAISAL}' (matrix='${{ matrix.appraisal }}', ruby='${{ matrix.ruby }}')"
           bin/test

--- a/.github/workflows/ci-latest.yml
+++ b/.github/workflows/ci-latest.yml
@@ -8,30 +8,24 @@ on:
   push:
     branches: [ develop ]
   workflow_dispatch:
-    inputs:
-      ruby:
-        description: 'Ruby version'
-        required: true
-        default: '3.3'
-      appraisal:
-        description: 'Appraisal name (gemfile key)'
-        required: true
-        default: 'rails-8.0'
 
 jobs:
   latest:
     name: Run bin/test on latest combo
     runs-on: ubuntu-latest
+    env:
+      APPRAISAL: 'rails-8.0'
+      RUBY_VERSION: '3.3'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ github.event.inputs.ruby }}
+          ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - name: Install gems for appraisal
         run: |
-          bundle exec appraisal "${{ github.event.inputs.appraisal }}" bundle install --jobs 1 --retry 2
+          bundle exec appraisal "${APPRAISAL}" bundle install --jobs 1 --retry 2
       - name: Run bin/test
         run: |
-          APPRAISAL="${{ github.event.inputs.appraisal }}" bin/test
+          APPRAISAL="${APPRAISAL}" bin/test

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -13,20 +13,19 @@ jobs:
   unit-tests:
     name: Unit tests (matrix)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: [3.3]
-        appraisal: [rails-8.0]
+    env:
+      APPRAISAL: rails-8.0
+      RUBY_VERSION: 3.3
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - name: Install gems for appraisal
         run: |
-          bundle exec appraisal "${{ matrix.appraisal }}" bundle install --jobs 1 --retry 2
+          bundle exec appraisal "${APPRAISAL}" bundle install --jobs 1 --retry 2
       - name: Run unit tests only
         run: |
-          APPRAISAL="${{ matrix.appraisal }}" bin/test unit
+          APPRAISAL="${APPRAISAL}" bin/test unit

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   unit-tests:
-    name: Unit tests (matrix)
+    name: Unit tests on latest
     runs-on: ubuntu-latest
     env:
       APPRAISAL: rails-8.0


### PR DESCRIPTION
develop にマージしたら CI がコケてしまっていたので、修正します。ログをみると appraisal へ渡すパラメータが渡っておらず空文字になっていました：
```
Run bundle exec appraisal "" bundle install --jobs 1 --retry 2
  bundle exec appraisal "" bundle install --jobs 1 --retry 2
  shell: /usr/bin/bash -e {0}
Ambiguous command  matches [--help, --version, -?, -D, -h, -v, clean, generate, help, install, list, update, version]
Error: Process completed with exit code 1.
```

ついでなので見直しも入れています。

---

This pull request simplifies the configuration of the GitHub Actions workflows by removing the use of input parameters and matrix strategies for Ruby and Appraisal versions. Instead, it sets these values directly as environment variables, making the workflows easier to read and maintain.

**Workflow configuration simplification:**

* [`.github/workflows/ci-latest.yml`](diffhunk://#diff-9d7d8b12bc3080502b4705f504850982b5a3b738463598cb898017e5aad613cbL11-R31): Removed workflow dispatch inputs for Ruby and Appraisal versions, and set `APPRAISAL` and `RUBY_VERSION` as environment variables instead. Updated all references in the workflow steps to use these environment variables.
* [`.github/workflows/ci-unit.yml`](diffhunk://#diff-87368594f9167faac7fec2c3c87d220280ef29f2acf1ed8b4455964454929237L16-R31): Removed the matrix strategy for Ruby and Appraisal versions, and set `APPRAISAL` and `RUBY_VERSION` as environment variables. Updated workflow steps to use these environment variables.