### PR TITLE
Fix: Importmap/Asset Pipeline Compatibility, System Test Resolution

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -109,25 +109,26 @@ bin/rails generate flash_unified:install
 
 **Importmap の場合**
 
-描画のタイミングを自動で設定する場合は `auto.js` を使います。`auto.js` は Turbo 連携のイベントの登録およびカスタムイベントの登録、そしてページの初回描画時の処理を自動で行います：
-
+`config/importmap.rb` に、使用する JavaScript を pin してください：
 ```ruby
+pin "flash_unified", to: "flash_unified/flash_unified.js"
+pin "flash_unified/network_helpers", to: "flash_unified/network_helpers.js"
+pin "flash_unified/turbo_helpers", to: "flash_unified/turbo_helpers.js"
 pin "flash_unified/auto", to: "flash_unified/auto.js"
 ```
 
-`auto.js` はページの再描画に関わるイベントをいくつか追加しますが、そうしたイベントを自身で制御（実装）することがある場合は、代わりにコア・ライブラリである `flash_unified.js` を使って描画処理を独自に実装してください。またヘルパー `turbo_helpers.js` と `network_helpers.js` はオプションですので、利用するものだけ pin してください：
+描画のタイミングを自動で設定する場合は `auto.js` を使います。`auto.js` は Turbo 連携のイベントの登録およびカスタムイベントの登録、そしてページの初回描画時の処理を自動で行います。
 
-```ruby
-pin "flash_unified", to: "flash_unified/flash_unified.js"
-pin "flash_unified/turbo_helpers", to: "flash_unified/turbo_helpers.js"
-pin "flash_unified/network_helpers", to: "flash_unified/network_helpers.js"
-```
+そうしたイベントを自身で制御（実装）することがある場合は、コア・ライブラリである `flash_unified.js` を使って描画処理を独自に実装してください。その場合 `auto.js` は不要です。またヘルパー `turbo_helpers.js` と `network_helpers.js` はオプションですので、利用するものだけ pin してください。
 
 **アセットパイプライン（Propshaft / Sprockets） の場合**
 
 この gem が提供する JavaScript は ES モジュールですので、上述 `pin` の代わりに、レイアウトなど適切な箇所に次のように設置します：
 ```erb
 <script type="module">
+  import "<%= asset_path('flash_unified/flash_unified.js') %>";
+  import "<%= asset_path('flash_unified/network_helpers.js') %>";
+  import "<%= asset_path('flash_unified/turbo_helpers.js') %>";
   import "<%= asset_path('flash_unified/auto.js') %>";
 </script>
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -125,11 +125,22 @@ pin "flash_unified/auto", to: "flash_unified/auto.js"
 
 この gem が提供する JavaScript は ES モジュールですので、上述 `pin` の代わりに、レイアウトなど適切な箇所に次のように設置します：
 ```erb
+<link rel="modulepreload" href="<%= asset_path('flash_unified/flash_unified.js') %>">
+<link rel="modulepreload" href="<%= asset_path('flash_unified/network_helpers.js') %>">
+<link rel="modulepreload" href="<%= asset_path('flash_unified/turbo_helpers.js') %>">
+<link rel="modulepreload" href="<%= asset_path('flash_unified/auto.js') %>">
+<script type="importmap">
+  {
+    "imports": {
+      "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+      "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+      "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+      "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+    }
+  }
+</script>
 <script type="module">
-  import "<%= asset_path('flash_unified/flash_unified.js') %>";
-  import "<%= asset_path('flash_unified/network_helpers.js') %>";
-  import "<%= asset_path('flash_unified/turbo_helpers.js') %>";
-  import "<%= asset_path('flash_unified/auto.js') %>";
+  import "flash_unified/auto";
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,28 +110,30 @@ bin/rails generate flash_unified:install
 
 ### 2. Add JavaScript
 
-Importmap:
+**Importmap:**
 
-If you want the library to set up rendering timing automatically, use `auto.js`. `auto.js` will register Turbo integration events, custom event listeners, and perform initial render handling automatically.
+`config/importmap.rb` should pin the JavaScript modules you use. The installer generator and sandbox templates pin all shipped modules, but if you manage pins manually, include at least the following:
 
 ```ruby
 pin "flash_unified/auto", to: "flash_unified/auto.js"
-```
-
-`auto.js` registers several events related to page re-rendering. If you want to control those events yourself, use the core `flash_unified.js` and manually set up handlers. For example, call `installInitialRenderListener()` to handle the initial render, call `installTurboRenderListeners()` (from `flash_unified/turbo_helpers`) to register Turbo lifecycle hooks, and call `installCustomEventListener()` to subscribe to `flash-unified:messages`. `turbo_helpers.js` and `network_helpers.js` are optional—pin only the ones you will use:
-
-```ruby
 pin "flash_unified", to: "flash_unified/flash_unified.js"
 pin "flash_unified/turbo_helpers", to: "flash_unified/turbo_helpers.js"
 pin "flash_unified/network_helpers", to: "flash_unified/network_helpers.js"
 ```
 
-Asset pipeline (Propshaft / Sprockets):
+If you want the library to set up rendering timing automatically, use `auto.js`. `auto.js` will register Turbo integration events, custom event listeners, and perform initial render handling automatically.
+
+If you prefer to control those events yourself, import the core `flash_unified` module and call the provided helpers (for example, `installInitialRenderListener()` for initial render, `installTurboRenderListeners()` from `flash_unified/turbo_helpers` for Turbo lifecycle hooks, and `installCustomEventListener()` to subscribe to `flash-unified:messages`). `turbo_helpers.js` and `network_helpers.js` are optional—pin only the ones you will use.
+
+**Asset pipeline (Propshaft / Sprockets):**
 
 Since the JavaScript is an ES module, instead of pinning, import it from your layout as a module:
 
 ```erb
 <script type="module">
+  import "<%= asset_path('flash_unified/flash_unified.js') %>";
+  import "<%= asset_path('flash_unified/network_helpers.js') %>";
+  import "<%= asset_path('flash_unified/turbo_helpers.js') %>";
   import "<%= asset_path('flash_unified/auto.js') %>";
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -127,14 +127,24 @@ If you prefer to control those events yourself, import the core `flash_unified` 
 
 **Asset pipeline (Propshaft / Sprockets):**
 
-Since the JavaScript is an ES module, instead of pinning, import it from your layout as a module:
-
+This gem's JavaScript is provided as ES modules. Instead of `pin`ning, add the following to an appropriate place in your layout:
 ```erb
+<link rel="modulepreload" href="<%= asset_path('flash_unified/flash_unified.js') %>">
+<link rel="modulepreload" href="<%= asset_path('flash_unified/network_helpers.js') %>">
+<link rel="modulepreload" href="<%= asset_path('flash_unified/turbo_helpers.js') %>">
+<link rel="modulepreload" href="<%= asset_path('flash_unified/auto.js') %>">
+<script type="importmap">
+  {
+    "imports": {
+      "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+      "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+      "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+      "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+    }
+  }
+</script>
 <script type="module">
-  import "<%= asset_path('flash_unified/flash_unified.js') %>";
-  import "<%= asset_path('flash_unified/network_helpers.js') %>";
-  import "<%= asset_path('flash_unified/turbo_helpers.js') %>";
-  import "<%= asset_path('flash_unified/auto.js') %>";
+  import "flash_unified/auto";
 </script>
 ```
 

--- a/app/javascript/flash_unified/auto.js
+++ b/app/javascript/flash_unified/auto.js
@@ -25,8 +25,8 @@
   - Set <html data-flash-unified-enable-network-errors="true"> to enable network error handling
 */
 
-import { installTurboIntegration, installNetworkErrorListeners } from './turbo_helpers.js';
-import { installInitialRenderListener } from './flash_unified.js';
+import { installTurboIntegration, installNetworkErrorListeners } from 'flash_unified/turbo_helpers';
+import { installInitialRenderListener } from 'flash_unified';
 
 if (typeof document !== 'undefined') {
   const root = document.documentElement;

--- a/app/javascript/flash_unified/network_helpers.js
+++ b/app/javascript/flash_unified/network_helpers.js
@@ -19,7 +19,7 @@
     notifyHttpError(413);   // Add HTTP-specific message and render
 */
 
-import { renderFlashMessages, appendMessageToStorage, storageHasMessages } from './flash_unified.js';
+import { renderFlashMessages, appendMessageToStorage, storageHasMessages } from 'flash_unified';
 
 /* エラーステータスに応じた汎用メッセージをストレージへ追加します。
   既にストレージにメッセージが存在する場合は何もしません。

--- a/app/javascript/flash_unified/turbo_helpers.js
+++ b/app/javascript/flash_unified/turbo_helpers.js
@@ -17,8 +17,8 @@
     // installInitialRenderListener();
 */
 
-import { renderFlashMessages, installCustomEventListener } from './flash_unified.js';
-import { resolveAndAppendErrorMessage } from './network_helpers.js';
+import { renderFlashMessages, installCustomEventListener } from 'flash_unified';
+import { resolveAndAppendErrorMessage } from 'flash_unified/network_helpers';
 
 /* Turbo関連のイベントリスナーを設定します。
   ページ遷移やフレーム更新時に自動的にフラッシュメッセージを描画します。

--- a/lib/generators/flash_unified/install/install_generator.rb
+++ b/lib/generators/flash_unified/install/install_generator.rb
@@ -52,7 +52,9 @@ module FlashUnified
 
             Quick start (auto init):
 
-              import "flash_unified/auto"; // Sets up Turbo listeners and renders on load
+              Importing `flash_unified/auto` sets up Turbo listeners and triggers an initial render.
+
+              import "flash_unified/auto";
               // Configure via <html data-flash-unified-*>:
               //   data-flash-unified-auto-init="false" (opt-out)
               //   data-flash-unified-enable-network-errors="true" (install Turbo network error listeners)
@@ -69,12 +71,27 @@ module FlashUnified
               // notifyNetworkError();
               // notifyHttpError(413);
 
-          - Asset pipeline (Propshaft / Sprockets): the engine adds its `app/javascript` to the asset paths; import via an inline module script in your layout's <head>:
+          - Asset pipeline (Propshaft / Sprockets): the engine adds its `app/javascript` to the asset paths; add modulepreload links and an inline importmap in your layout's `<head>` and import the bare specifier.
 
+              <link rel="modulepreload" href="<%= asset_path('flash_unified/flash_unified.js') %>">
+              <link rel="modulepreload" href="<%= asset_path('flash_unified/network_helpers.js') %>">
+              <link rel="modulepreload" href="<%= asset_path('flash_unified/turbo_helpers.js') %>">
               <link rel="modulepreload" href="<%= asset_path('flash_unified/auto.js') %>">
-              <script type="module">
-                import "<%= asset_path('flash_unified/auto.js') %>";
+              <script type="importmap">
+                {
+                  "imports": {
+                    "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+                    "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+                    "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+                    "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+                  }
+                }
               </script>
+              <script type="module">
+                import "flash_unified/auto";
+              </script>
+
+              Remove the `import "flash_unified/auto";` line if you don't want automatic initialization.
 
           How to place partials in your layout
           - The gem's view helpers render engine partials. After running this generator you'll have the partials available under `app/views/flash_unified` and can customize them as needed.

--- a/sandbox/templates/propshaft.rb
+++ b/sandbox/templates/propshaft.rb
@@ -6,10 +6,22 @@ after_bundle do
   # Inject module script into application layout to import via asset pipeline
   layout_file = 'app/views/layouts/application.html.erb'
   module_script = <<~ERB
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/flash_unified.js') %>">
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/network_helpers.js') %>">
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/turbo_helpers.js') %>">
     <link rel="modulepreload" href="<%= asset_path('flash_unified/auto.js') %>">
+    <script type="importmap">
+      {
+        "imports": {
+          "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+          "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+          "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+          "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+        }
+      }
+    </script>
     <script type="module">
-      import "<%= asset_path('flash_unified/auto.js') %>";
-      <!-- Optionally control via <html data-flash-unified-*> attributes -->
+      import "flash_unified/auto";
     </script>
   ERB
 

--- a/sandbox/templates/sprockets.rb
+++ b/sandbox/templates/sprockets.rb
@@ -6,10 +6,22 @@ after_bundle do
   # Inject module script into application layout to import via asset pipeline
   layout_file = 'app/views/layouts/application.html.erb'
   module_script = <<~ERB
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/flash_unified.js') %>">
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/network_helpers.js') %>">
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/turbo_helpers.js') %>">
     <link rel="modulepreload" href="<%= asset_path('flash_unified/auto.js') %>">
+    <script type="importmap">
+      {
+        "imports": {
+          "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+          "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+          "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+          "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+        }
+      }
+    </script>
     <script type="module">
-      import "<%= asset_path('flash_unified/auto.js') %>";
-      <!-- Optionally control via <html data-flash-unified-*> attributes -->
+      import "flash_unified/auto";
     </script>
   ERB
 

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -6,13 +6,28 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/flash_unified.js') %>">
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/network_helpers.js') %>">
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/turbo_helpers.js') %>">
+    <link rel="modulepreload" href="<%= asset_path('flash_unified/auto.js') %>">
+    <script type="importmap">
+      {
+        "imports": {
+          "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+          "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+          "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+          "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+        }
+      }
+    </script>
+
     <%= stylesheet_link_tag "application" %>
 
     <%= javascript_include_tag "turbo", type: "module" %>
 
     <script type="module">
       // Use convenience auto entry to install Turbo listeners and render on load
-      import "<%= asset_path('flash_unified/auto.js') %>";
+      import "flash_unified/auto";
     </script>
   </head>
 

--- a/test/dummy/app/views/layouts/flash_unified_auto_off.html.erb
+++ b/test/dummy/app/views/layouts/flash_unified_auto_off.html.erb
@@ -5,11 +5,21 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <script type="importmap">
+    {
+      "imports": {
+        "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+        "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+        "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+        "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+      }
+    }
+    </script>
     <%= stylesheet_link_tag "application" %>
     <%= javascript_include_tag "turbo", type: "module" %>
     <script type="module">
       // Note: no auto.js import here to prove opt-out works
-      import { renderFlashMessages } from "<%= asset_path('flash_unified/flash_unified.js') %>";
+      import { renderFlashMessages } from "flash_unified";
       // Expose manual render hook for tests
       window.__manualRenderFlash__ = () => renderFlashMessages();
     </script>

--- a/test/dummy/app/views/layouts/flash_unified_test.html.erb
+++ b/test/dummy/app/views/layouts/flash_unified_test.html.erb
@@ -5,12 +5,22 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <script type="importmap">
+    {
+      "imports": {
+        "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+        "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+        "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+        "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+      }
+    }
+    </script>
     <%= stylesheet_link_tag "application" %>
     <%= javascript_include_tag "turbo", type: "module" %>
     <script type="module">
       // Use auto entry + an extra render after init for test expectations
-      import "<%= asset_path('flash_unified/auto.js') %>";
-      import { renderFlashMessages } from "<%= asset_path('flash_unified/flash_unified.js') %>";
+      import "flash_unified/auto";
+      import { renderFlashMessages } from "flash_unified";
       const init = () => { Promise.resolve().then(() => renderFlashMessages()); };
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", init);

--- a/test/dummy/app/views/layouts/flash_unified_test_nowarning.html.erb
+++ b/test/dummy/app/views/layouts/flash_unified_test_nowarning.html.erb
@@ -5,11 +5,21 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <script type="importmap">
+    {
+      "imports": {
+        "flash_unified": "<%= asset_path('flash_unified/flash_unified.js') %>",
+        "flash_unified/auto": "<%= asset_path('flash_unified/auto.js') %>",
+        "flash_unified/turbo_helpers": "<%= asset_path('flash_unified/turbo_helpers.js') %>",
+        "flash_unified/network_helpers": "<%= asset_path('flash_unified/network_helpers.js') %>"
+      }
+    }
+    </script>
     <%= stylesheet_link_tag "application" %>
     <%= javascript_include_tag "turbo", type: "module" %>
     <script type="module">
-      import "<%= asset_path('flash_unified/auto.js') %>";
-      import { renderFlashMessages } from "<%= asset_path('flash_unified/flash_unified.js') %>";
+      import "flash_unified/auto";
+      import { renderFlashMessages } from "flash_unified";
       const init = () => { Promise.resolve().then(() => renderFlashMessages()); };
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
Rails における importmap ではすべての JavaScript ソースを pin する必要がありました。ソースファイルにはファイル名に署名がつくため、ソース内に書かれた from "script.js" といった import は、ブラウザが読み込む段階では存在しないファイルになります。 pin をして、識別名とファイルとのマッピングを保ち、スクリプトからは識別名を扱うようにします。

またアセット・パイプラインで使う場合のガイドを修正します。

テストも修正しています。

---
(差分を読ませて GPT-4.1 に作成させた PR の詳細文）

このPRはFlashUnified gemのImportmap/アセットパイプライン対応、システムテストのモジュール解決、ドキュメント・ジェネレータの同期を目的とした修正を含みます。

主な変更点:
- ESモジュールのbare specifier化に伴い、dummy appのテスト用レイアウトにimportmap＋modulepreloadを追加し、system testでのモジュール解決エラー（Ferrum/Chrome）を解消
- README（日本語/英語）およびジェネレータ出力を最新のImportmap/Propshaft/Sprockets両対応の内容に統一
- 不要な初期化ファイル（flash_unified_asset_paths.rb）を削除
- pinning推奨理由の明記、セットアップガイドの明確化
- テスト・サンドボックス・Appraisal環境での動作確認済み

技術的アプローチ:
- 1セットのESM（bare specifier）＋importmapでImportmap/Propshaft/Sprockets両対応
- DOM契約・初期化・Turbo/ネットワークエラー対応も一貫性を維持
- サーバー/クライアント分離設計、拡張性・保守性を重視

このPRにより、gemの導入・運用・テスト・ドキュメントが現代的なRails環境に最適化されます。

ご確認・レビューをお願いします。

---
(GitHub Copilotによる PR の詳細文）

This pull request updates the installation and usage instructions for the `flash_unified` JavaScript modules to use bare module specifiers and importmaps, and refactors internal imports for consistency. The changes improve compatibility and clarity for both Importmap and asset pipeline setups, and ensure documentation, templates, and code samples are aligned with best practices.

**Documentation and Setup Improvements:**

* Updated `README.md` and `README.ja.md` to clarify Importmap usage, show explicit pinning of all shipped modules, and provide improved asset pipeline instructions with modulepreload links and inline importmap examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R147) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L112-R143)
* Refined generator output (`install_generator.rb`) and sandbox templates (`propshaft.rb`, `sprockets.rb`) to inject modulepreload links and importmap blocks, and to use bare specifiers in `<script type="module">` imports. [[1]](diffhunk://#diff-f8ead60bc8f393b73a826a9fe12601e9e5c6b0abc3c219e7aeefbe96184d7f9aL55-R57) [[2]](diffhunk://#diff-f8ead60bc8f393b73a826a9fe12601e9e5c6b0abc3c219e7aeefbe96184d7f9aL72-R95) [[3]](diffhunk://#diff-ad2f7232148bf492d087bff11588f52d842bed43977eac052589d025028e6ad8R9-R24) [[4]](diffhunk://#diff-33315bf599ca3dba565786a9c08c09025bb16448355efd08f2034b47d4b4d1d5R9-R24)

**Code Refactoring:**

* Refactored internal JavaScript imports in `auto.js`, `network_helpers.js`, and `turbo_helpers.js` to use bare module specifiers (e.g., `import ... from 'flash_unified'`) for consistency with importmap usage. [[1]](diffhunk://#diff-20d0a69d0e77044af5e5dc3da23dad40c44fd66ceb14782cf1b49298cd1cd94aL28-R29) [[2]](diffhunk://#diff-22dbcdbd62944d934801ab13f5f58a54ea854ae92b80876be6b28724d040de98L22-R22) [[3]](diffhunk://#diff-d311d365cb354a37445761b5b79e8d2be115bf78332d78a6cfaa862b5a427b4aL20-R21)

**Test and Example Updates:**

* Updated example layouts and test views to use importmaps and bare module specifiers for all `flash_unified` modules, replacing previous direct asset path imports. [[1]](diffhunk://#diff-43c0412d37f1d3c86ead260125fae5c3c25333954d806e7482770f1bca33f25dR9-R30) [[2]](diffhunk://#diff-e0ee1ba260eb5fc193db3a6ebe7aa0d49922722bffb94a1444393b949c9f32a0R8-R22) [[3]](diffhunk://#diff-8f82f98d3b5742c798d52da4923b00cf6e5f9d084b9493a8b35b396193a89410R8-R23) [[4]](diffhunk://#diff-0af3e4af78a1650aba400d7e460b55fba59cc098f117d864f00719ad69a3ca6aR8-R22)