### PR TITLE
Add Rails version validation for --rails / RAILS_VERSION in bin/sandbox

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: bin/sandbox <variant> [--path <path_to_gem_root>] [--scaffold]
+# Usage: bin/sandbox <variant> [--path <path_to_gem_root>] [--scaffold] [--rails <version>]
 # Variants:
 #   importmap   -> Rails app with importmap JS (default), asset pipeline default
 #   propshaft   -> Rails app with importmap JS and Propshaft asset pipeline
@@ -10,6 +10,7 @@ set -euo pipefail
 #   bin/sandbox importmap
 #   bin/sandbox propshaft --path ../..   # explicit relative path (when pushing sandbox branch)
 #   bin/sandbox sprockets --scaffold     # optional scaffold and migrate
+#   bin/sandbox importmap --rails 7.1.0   # specify Rails version
 #
 # By default, this script writes a RELATIVE path to the gem into the sandbox Gemfile
 # (e.g. '../..' from sandbox/<name> to the repo root) so that the sandbox can be
@@ -21,7 +22,7 @@ set -euo pipefail
 
 NAME=${1:-}
 if [[ -z "$NAME" ]]; then
-  echo "Usage: $(basename "$0") <variant: importmap|propshaft|sprockets> [--path <gem_path>] [--scaffold]" >&2
+  echo "Usage: $(basename "$0") <variant: importmap|propshaft|sprockets> [--path <gem_path>] [--scaffold] [--rails <version>]" >&2
   exit 1
 fi
 
@@ -32,6 +33,9 @@ ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 GEM_PATH="$ROOT_DIR"   # Will be replaced with a relative path unless --path is given
 GEM_PATH_OVERRIDDEN=false
 DO_SCAFFOLD=false
+
+# Allow setting Rails version via env var; CLI --rails overrides it
+RAILS_VERSION="${RAILS_VERSION:-}"
 
 # Parse optional flags
 shift
@@ -46,12 +50,35 @@ while (( $# )); do
       DO_SCAFFOLD=true
       shift 1
       ;;
+    --rails)
+      if [[ -z "${2:-}" ]]; then
+        echo "Missing argument for --rails" >&2
+        exit 1
+      fi
+      RAILS_VERSION="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown option: $1" >&2
       exit 1
       ;;
   esac
 done
+
+# Validate requested Rails version (if any)
+if [[ -n "$RAILS_VERSION" ]]; then
+  # Check that the version exists on RubyGems
+  if ! gem specification rails -v "$RAILS_VERSION" --remote >/dev/null 2>&1; then
+    echo "Rails version '$RAILS_VERSION' not found on RubyGems." >&2
+    exit 1
+  fi
+
+  # If not installed locally, fail with a warning (don't auto-install)
+  if ! gem list -i rails -v "$RAILS_VERSION" >/dev/null 2>&1; then
+    echo "Rails $RAILS_VERSION is not installed locally. Please install it (e.g. 'gem install rails -v $RAILS_VERSION') and re-run this script." >&2
+    exit 1
+  fi
+fi
 
 SANDBOX_DIR="$ROOT_DIR/sandbox/$NAME"
 
@@ -63,7 +90,12 @@ fi
 mkdir -p "$ROOT_DIR/sandbox"
 
 # Build rails new command with appropriate JS and asset pipeline settings
-rails_new=(rails new "$NAME" --skip-git --skip-bundle)
+# If RAILS_VERSION is provided, call rails _<version>_ new ...
+rails_new=(rails)
+if [[ -n "$RAILS_VERSION" ]]; then
+  rails_new+=("_${RAILS_VERSION}_")
+fi
+rails_new+=(new "$NAME" --skip-git --skip-bundle)
 case "$NAME" in
   importmap)
     rails_new+=(--javascript=importmap)
@@ -108,7 +140,7 @@ FLASH_UNIFIED_SCAFFOLD=$([[ "$DO_SCAFFOLD" == "true" ]] && echo 1 || echo 0) \
   bin/rails app:template LOCATION="$APP_TEMPLATE"
 
 # Done
-RELATIVE_SANDBOX_DIR=$(ruby -r pathname -e 'puts Pathname.new(ARGV[0]).relative_path_from(ARGV[1])' "$SANDBOX_DIR" "$ROOT_DIR")
+RELATIVE_SANDBOX_DIR=$(ruby -r pathname -e 'puts Pathname.new(ARGV[0]).relative_path_from(Pathname.new(ARGV[1]) )' "$SANDBOX_DIR" "$ROOT_DIR")
 cat <<EOM
 
 Sandbox created at: $RELATIVE_SANDBOX_DIR


### PR DESCRIPTION
## Summary

- Validate the Rails version provided via the --rails option or the RAILS_VERSION environment variable.
- If the requested version does not exist on RubyGems, the script prints an error and exits.
- If the version exists on RubyGems but is not installed locally, the script warns the user and exits (does not attempt to install).

## Files changed

- bin/sandbox
  - Add check using `gem specification rails -v <version> --remote` to verify the version exists on RubyGems.
  - Add local installation check (`gem list -i rails -v <version>`) and a user-facing warning that asks the user to install the gem and re-run the script.

## Behavior / Usage

- Existing behavior is unchanged when --rails is not provided.
- Examples:
  - Valid and installed: RAILS_VERSION=7.1.4 bin/sandbox importmap
  - Exists but not installed: bin/sandbox importmap --rails 7.1.4
    - Output: "Rails 7.1.4 is not installed locally. Please install it (e.g. 'gem install rails -v 7.1.4') and re-run this script."
  - Does not exist: RAILS_VERSION=0.0.0 bin/sandbox importmap
    - Output: "Rails version '0.0.0' not found on RubyGems."

## Testing notes

- Verify that a nonexistent version fails quickly with the RubyGems not found message.
- Verify that an existing-but-not-installed version prints the install instruction and exits.
- Verify normal sandbox creation when no version is provided or when a valid installed version is specified.

## Rationale

- Fail fast on mis-typed or unsupported Rails versions to avoid confusing errors later during sandbox creation.
- Avoid automatic gem installation to keep the script non-invasive and predictable across developer environments.

If you prefer an alternative behavior (e.g. offer an automatic install option), I can prepare a follow-up change to add a --install-rails flag.

-----

# bin/sandbox に --rails 指定時のバージョン検証を追加

## 概要

- bin/sandbox スクリプトにて、--rails オプション（または環境変数 RAILS_VERSION）で指定された Rails バージョンが存在するかを検証する処理を追加しました。
- 存在しないバージョンを指定した場合はエラーメッセージを出力して終了します。
- 指定バージョンが RubyGems 上に存在するがローカルにインストールされていない場合は、インストールを自動で行わず警告を出して終了します（ユーザに手動インストールを案内）。

## 変更箇所

- ファイル: bin/sandbox
  - RubyGems 上の該当 Rails バージョン有無を gem specification rails -v <version> --remote でチェック
  - ローカル未インストール時は "Please install it (e.g. 'gem install rails -v ...')" を出力して終了する挙動にする

## 動作例（検証方法）

- 存在しないバージョンで失敗することの確認:
  - RAILS_VERSION=0.0.0 bin/sandbox importmap
  - 出力例: "Rails version '0.0.0' not found on RubyGems."
- 存在はするがローカル未インストールで失敗することの確認:
  - bin/sandbox importmap --rails <installed-on-rubygems-but-not-local>
  - 出力例: "Rails <version> is not installed locally. Please install it (e.g. 'gem install rails -v <version>') and re-run this script."

## 影響範囲

- --rails 未指定時の既存挙動に変更はありません。
- 指定バージョンが誤っている場合に早期に検出できるため、サンドボックス作成失敗時の原因特定が容易になります。

## 備考

- 自動インストールは行わない方針（堅牢性・環境差異回避のため）。必要であれば将来的に自動インストールオプションを追加できます。